### PR TITLE
Update recaptcha.mdx

### DIFF
--- a/craft-freeform/integrations/recaptcha.mdx
+++ b/craft-freeform/integrations/recaptcha.mdx
@@ -119,7 +119,7 @@ If you'd like to have the associated Captcha scripts load only once a user begin
 
 ### Disabling Captchas
 
-To disable Captchas per form at template level, add the `disableCaptcha: true` parameter to the [Form query](../templates/queries/form.mdx).
+To disable Captchas per form at template level, add the `disable: { captchas: true }` parameter to the [Form query](../templates/queries/form.mdx#disable).
 
 ### Manual Placement<Badge type="feature" text="New in 5.7+" />
 


### PR DESCRIPTION
Added hash to link to point directly to docs section.

I found this section confusing until I realised the instructions were wrong.

I'm still confused if the disable parameter will work when rendering the form eg:

```twig
{{ form.renderTag({
    disable: {
        captchas: getenv('CRAFT_RECAPTCHA_DISABLED'),
    }
}) }}
```

I'm accessing the form element directly from the `form` field type which provides an instance of the form object. Do I need to create a new query with the `form.handle` and pass the `disable` param to that as per the docs:

```twig
{{ freeform.form(entry.formField.handle, {
    disable: {
        captchas: getenv('CRAFT_RECAPTCHA_DISABLED'),
    }
}) }}
```