### PR TITLE
Rename 'error' attribute to 'errors' in documentation

### DIFF
--- a/craft-freeform/templates/formatting/index.mdx
+++ b/craft-freeform/templates/formatting/index.mdx
@@ -319,7 +319,7 @@ Here's a breakdown:
       - `row` - applied directly to form `<div>` rows.
       - `column` - applied directly to form `<div>` columns.
       - `success` - applied directly to Success banner wrapper `div`.
-      - `error` - applied directly to Error banner wrapper `div`.
+      - `errors` - applied directly to Error banner wrapper `div`.
 
   </TabItem>
   <TabItem value="overrides-buttons" label="Buttons">


### PR DESCRIPTION
Example templates all have `errors` not `error`.

<img width="802" height="398" alt="image" src="https://github.com/user-attachments/assets/fe661567-3cd3-43af-bd58-163000eac9e1" />

A related point of possible confusion is that this doesn't seem to change the ajax error / success message. For that you need  to have a custom javascript plugin to edit the plugin options.

Given these values are being defined couldn't any classes / properties be added in as a data attribute and then merged onto the success banner. Even better rendering the success / error banner as a data attribute and using it directly?

<img width="1100" height="887" alt="image" src="https://github.com/user-attachments/assets/8f133749-ba75-411d-9c5b-04792d5798af" />


